### PR TITLE
fix: catchEvent empty points, 不传入el，用catchEvent传入事件的方式，points无法初始化

### DIFF
--- a/packages/core/src/createInput/touch.ts
+++ b/packages/core/src/createInput/touch.ts
@@ -16,6 +16,12 @@ export default function (el?: Element) {
                 targets.push(target);
                 points.push({ clientX, clientY, target });
             }
+            // 未指定根元素的情况下，应当将所有touch点都视作有效，
+            // 否则points为空，将会报错
+            if (!el) {
+                if (target) targets.push(target);
+                points.push({ clientX, clientY, target });
+            }
         });
         const changedPoints = Array.from(event.changedTouches).map(({ clientX, clientY, target }) => ({ clientX, clientY, target }));
         return createInput({


### PR DESCRIPTION
不传入el，用catchEvent传入事件的方式，points无法初始化

``` javascript
const at = new AnyTouch();
at.catchEvent(touchevent);
```
这种方式使用会报错，原因是createInput的过程中在判断 eventTarget 是否在根元素下时，由于未指定根元素，导致所有的touch点都被过滤了。于是后续处理过程中points全是空数组，导致报错。